### PR TITLE
#13 implemented login endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
 			<scope>runtime</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mapstruct</groupId>
+			<artifactId>mapstruct</artifactId>
+			<version>1.4.2.Final</version>
+		</dependency>
+
 <!--		<dependency>-->
 <!--			<groupId>org.springframework.cloud</groupId>-->
 <!--			<artifactId>spring-cloud-starter-sleuth</artifactId>-->

--- a/user-service/src/main/java/com/rafantasy/userservice/UserServiceApplication.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/UserServiceApplication.java
@@ -3,9 +3,11 @@ package com.rafantasy.userservice;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableFeignClients
 public class UserServiceApplication {
 
 	public static void main(String[] args) {

--- a/user-service/src/main/java/com/rafantasy/userservice/feign/KeyCloakClient.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/feign/KeyCloakClient.java
@@ -1,0 +1,27 @@
+package com.rafantasy.userservice.feign;
+
+import com.rafantasy.userservice.security.dto.LoginRequestDTO;
+import com.rafantasy.userservice.security.dto.LoginResponseDTO;
+import feign.form.spring.SpringFormEncoder;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "keycloak-client", url = "${keycloak.auth-server-url}", configuration = KeyCloakClient.Configuration.class)
+public interface KeyCloakClient {
+
+    @PostMapping(value = "/realms/${keycloak.realm}/protocol/openid-connect/token",
+            consumes = "application/x-www-form-urlencoded")
+    LoginResponseDTO login(@RequestBody LoginRequestDTO loginRequestDTO);
+
+    class Configuration {
+        @Bean
+        SpringFormEncoder feignFormEncoder(ObjectFactory<HttpMessageConverters> converters) {
+            return new SpringFormEncoder(new SpringEncoder(converters));
+        }
+    }
+}

--- a/user-service/src/main/java/com/rafantasy/userservice/security/KeyCloakSecurityConfig.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/KeyCloakSecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
@@ -47,16 +46,8 @@ public class KeyCloakSecurityConfig extends KeycloakWebSecurityConfigurerAdapter
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         super.configure(http);
-//        http.cors().and().csrf().disable()
-//                .sessionManagement()
-//                .sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
-//                .authorizeRequests()
-//                .antMatchers("/api/auth/**").permitAll()
-//                .anyRequest().authenticated();
-
-        http.authorizeRequests()
-                .antMatchers("/api/users/**")
-                .hasRole("user")
+        http.cors().and().csrf().disable().authorizeRequests()
+                .antMatchers("/api/users/**").hasRole("user")
                 .anyRequest()
                 .permitAll();
     }

--- a/user-service/src/main/java/com/rafantasy/userservice/security/controller/AuthController.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/controller/AuthController.java
@@ -1,34 +1,34 @@
-//package com.rafantasy.userservice.security.controller;
-//
-//import com.rafantasy.userservice.security.dto.*;
-//import com.rafantasy.userservice.security.enums.TokenType;
-//import com.rafantasy.userservice.security.service.AuthService;
-//import com.rafantasy.userservice.security.dto.*;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.web.bind.annotation.*;
-//
-//import javax.validation.Valid;
-//
-//@RestController
-//@RequiredArgsConstructor
-//@RequestMapping("/api/auth")
-//public class AuthController {
-//
-//    private final AuthService authService;
-//
-//    /**
-//     * Method to authenticate a user.
-//     *
-//     * @param loginRequestDTO The login request dto.
-//     * @return The login response, on successful authentication.
-//     */
-//    @PostMapping("/login")
-//    public LoginResponseDTO login(@RequestBody LoginRequestDTO loginRequestDTO) {
-//        return authService.login(loginRequestDTO);
-//    }
-//
-//    /**
+package com.rafantasy.userservice.security.controller;
+
+import com.rafantasy.userservice.security.dto.LoginRequestDTO;
+import com.rafantasy.userservice.security.dto.LoginResponseDTO;
+import com.rafantasy.userservice.security.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * Method to authenticate a user.
+     *
+     * @param loginRequestDTO The login request dto.
+     * @return The login response, on successful authentication.
+     */
+    @PostMapping("/login")
+    public LoginResponseDTO login(@RequestBody LoginRequestDTO loginRequestDTO) {
+        return authService.login(loginRequestDTO);
+    }
+
+//    /** //todo
 //     * Method to register -- a new user.
 //     *
 //     * @param signUpRequestDTO Signup dto with all of the required information.
@@ -38,60 +38,4 @@
 //    public ResponseEntity<String> signUp(@RequestBody SignUpRequestDTO signUpRequestDTO) {
 //        return authService.signUp(signUpRequestDTO);
 //    }
-//
-//    /**
-//     * Method to check if a user already exists by username or email.
-//     *
-//     * @param inputValue The input-value, can be an email or a username.
-//     * @return True if exists, False otherwise.
-//     */
-//    @GetMapping("/exists-by-username-or-email/{input-value}")
-//    public Boolean existsByUsername(@PathVariable("input-value") String inputValue) {
-//        return authService.exists(inputValue);
-//    }
-//
-//    /**
-//     * Method to request for password change.
-//     *
-//     * @param forgotPasswordDTO The forgot password dto.
-//     * @return ResponseEntity object.
-//     */
-//    @PostMapping("/forgot-password")
-//    public ResponseEntity<String> passwordResetRequest(@RequestBody ForgotPasswordDTO forgotPasswordDTO) {
-//        return authService.forgotPasswordRequest(forgotPasswordDTO);
-//    }
-//
-//    /**
-//     * Method to confirm the authenticity of a token, used either for signup or reset password.
-//     *
-//     * @param token     The token.
-//     * @param tokenType The tokentype - either forgotPassword or signup.
-//     * @return ConfirmTokenDto on successful validation.
-//     */
-//    @GetMapping("/confirm-token/{token-type}/{token}")
-//    public ConfirmTokenDTO confirmToken(@PathVariable("token") String token, @PathVariable("token-type") TokenType tokenType) {
-//        return authService.confirmToken(token, tokenType);
-//    }
-//
-//    /**
-//     * Method to reset the password.
-//     *
-//     * @param updatePasswordDTO DTO with appropriate fields to required to reset the password.
-//     * @return ResponseEntity on successful password change.
-//     */
-//    @PostMapping("/reset-password")
-//    public ResponseEntity<String> confirmResetPassword(@RequestBody UpdatePasswordDTO updatePasswordDTO) {
-//        return authService.resetPassword(updatePasswordDTO);
-//    }
-//
-//    /**
-//     * Method to refresh a JWT token.
-//     * @param refreshTokenRequestDTO DTO with Refresh token string.
-//     * @return New JWT Bearer Token.
-//     */
-//    @PostMapping("/refresh-token")
-//    public RefreshTokenResponseDto refreshToken(@RequestBody @Valid RefreshTokenRequestDTO refreshTokenRequestDTO) {
-//        return authService.refreshToken(refreshTokenRequestDTO);
-//    }
-//
-//}
+}

--- a/user-service/src/main/java/com/rafantasy/userservice/security/dto/LoginRequestDTO.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/dto/LoginRequestDTO.java
@@ -1,5 +1,6 @@
 package com.rafantasy.userservice.security.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -18,4 +19,8 @@ public class LoginRequestDTO {
 
     @NotBlank(message = "login.request.password.empty")
     private String password;
+
+    private String client_id;
+
+    private String grant_type;
 }

--- a/user-service/src/main/java/com/rafantasy/userservice/security/dto/LoginResponseDTO.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/dto/LoginResponseDTO.java
@@ -1,5 +1,6 @@
 package com.rafantasy.userservice.security.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,16 +14,22 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor
 public class LoginResponseDTO {
 
-    private String username;
+    @JsonProperty("token_type")
+    private String tokenType;
 
-//    private Integer id;
+    @JsonProperty("access_token")
+    private String accessToken;
 
-    private String jwt;
+    @JsonProperty("expires_in")
+    private Long expiresIn;
 
-    private String roles;
-
-    private Long expiryTime;
-
+    @JsonProperty("refresh_token")
     private String refreshToken;
+
+    @JsonProperty("refresh_expires_in")
+    private Long refreshExpiresIn;
+
+    @JsonProperty("session_state")
+    private String sessionState;
 
 }

--- a/user-service/src/main/java/com/rafantasy/userservice/security/service/AuthService.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/service/AuthService.java
@@ -1,32 +1,9 @@
 package com.rafantasy.userservice.security.service;
 
-import com.rafantasy.userservice.security.dto.*;
-import com.rafantasy.userservice.security.enums.TokenType;
-import com.rafantasy.userservice.security.model.RefreshToken;
-import com.rafantasy.userservice.security.dto.*;
-import org.springframework.http.ResponseEntity;
+import com.rafantasy.userservice.security.dto.LoginRequestDTO;
+import com.rafantasy.userservice.security.dto.LoginResponseDTO;
 
 public interface AuthService {
 
     LoginResponseDTO login(LoginRequestDTO loginRequestDTO);
-
-    ResponseEntity<String> signUp(SignUpRequestDTO signUpRequestDTO);
-
-    Boolean exists(String inputValue);
-
-    ResponseEntity<String> forgotPasswordRequest(ForgotPasswordDTO forgotPasswordDTO);
-
-    ConfirmTokenDTO confirmToken(String resetToken, TokenType tokenType);
-
-    ResponseEntity<String> resetPassword(UpdatePasswordDTO updatePasswordDTO);
-
-    RefreshToken findByToken(String token);
-
-    RefreshToken createRefreshToken(String username);
-
-    void deleteByUserId(Integer userId);
-
-    RefreshToken verifyExpiration(RefreshToken token);
-
-    RefreshTokenResponseDto refreshToken(RefreshTokenRequestDTO refreshTokenRequestDTO);
 }

--- a/user-service/src/main/java/com/rafantasy/userservice/security/service/AuthServiceImpl.java
+++ b/user-service/src/main/java/com/rafantasy/userservice/security/service/AuthServiceImpl.java
@@ -1,207 +1,31 @@
-//package com.rafantasy.userservice.security.service;
-//
-//import com.rafantasy.userservice.common.UserServiceProperties;
-//import com.rafantasy.userservice.common.Utils;
-//import com.rafantasy.userservice.domain.converter.RoleConverter;
-//import com.rafantasy.userservice.domain.model.RoleType;
-//import com.rafantasy.userservice.domain.model.User;
-//import com.rafantasy.userservice.domain.service.UserRepository;
-//import com.rafantasy.userservice.security.JwtUtils;
-//import com.rafantasy.userservice.security.UserDetailsImpl;
-//import com.rafantasy.userservice.security.dto.*;
-//import com.rafantasy.userservice.security.enums.TokenType;
-//import com.rafantasy.userservice.security.model.RefreshToken;
-//import com.rafantasy.userservice.common.Constants;
-//import com.rafantasy.userservice.security.dto.*;
-//import lombok.RequiredArgsConstructor;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.http.ResponseEntity;
-//import org.springframework.security.authentication.AuthenticationManager;
-//import org.springframework.security.authentication.BadCredentialsException;
-//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-//import org.springframework.security.core.GrantedAuthority;
-//import org.springframework.security.core.authority.SimpleGrantedAuthority;
-//import org.springframework.security.core.context.SecurityContextHolder;
-//import org.springframework.security.crypto.password.PasswordEncoder;
-//import org.springframework.stereotype.Service;
-//import org.springframework.transaction.annotation.Transactional;
-//import org.springframework.web.server.ResponseStatusException;
-//
-//import java.time.Instant;
-//import java.util.ArrayList;
-//import java.util.Set;
-//import java.util.UUID;
-//
-///**
-// * AuthService Implementation.
-// */
-//@Service
-//@RequiredArgsConstructor
-//public class AuthServiceImpl implements AuthService {
-//
-//    private final AuthenticationManager authenticationManager;
-//
-//    private final JwtUtils jwtUtils;
-//
-//    private final PasswordEncoder passwordEncoder;
-//
-//    private final UserRepository userRepository;
-//
-//    private final RoleConverter roleConverter;
-//
-//    private final Utils utils;
-//
-//    private final UserServiceProperties userServiceProperties;
-//
-//    private final RefreshTokenRepository refreshTokenRepository;
-//
-//    @Override
-//    public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
-//
-//        var authentication = authenticationManager.authenticate(
-//                new UsernamePasswordAuthenticationToken(loginRequestDTO.getUsername(), loginRequestDTO.getPassword())
-//        );
-//
-//        SecurityContextHolder.getContext().setAuthentication(authentication);
-//
-//        var userDetails = (UserDetailsImpl) authentication.getPrincipal();
-//
-//        var authorityString = jwtUtils.authorityToString(userDetails.getAuthorities());
-//
-//        var jwt = jwtUtils.generateJwt(userDetails.getUsername(), authorityString);
-//
-//        RefreshToken refreshToken = this.createRefreshToken(userDetails.getUsername());
-//
-//        return new LoginResponseDTO()
-//                .setJwt(jwt)
-//                .setExpiryTime(userServiceProperties.getJwtExpiryTimeInMs())
-//                .setRoles(authorityString)
-//                .setRefreshToken(refreshToken.getToken())
-//                .setUsername(userDetails.getUsername());
-//    }
-//
-//    @Override
-//    public ResponseEntity<String> signUp(SignUpRequestDTO signUpRequestDTO) {
-//        if (!userRepository.existsByEmailOrUsername(signUpRequestDTO.getEmail(), signUpRequestDTO.getUsername())) {
-//            String token = UUID.randomUUID().toString();
-//            var user = new User()
-//                    .setEmail(signUpRequestDTO.getEmail())
-//                    .setFirstName(signUpRequestDTO.getFirstName())
-//                    .setLastName(signUpRequestDTO.getLastName())
-//                    .setPassword(passwordEncoder.encode(signUpRequestDTO.getPassword()))
-//                    .setUsername(signUpRequestDTO.getUsername())
-//                    .setDateOfBirth(signUpRequestDTO.getDateOfBirth())
-//                    .setToken(token)
-//                    .setRoles(Set.of(roleConverter.convert(RoleType.ROLE_USER)));
-//            userRepository.save(user);
-//
-//            utils.sendMail(
-//                    user.getEmail(),
-//                    Constants.SIGNUP_SUBJECT,
-//                    String.format(Constants.SIGNUP_PASSWORD_CONTENT,
-//                            user.getFirstName(),
-//                            userServiceProperties.getFrontEndUrl(),
-//                            token));
-//            return ResponseEntity.ok(String.format("New User %s created", signUpRequestDTO.getUsername()));
-//        } else {
-//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, Constants.USER_ALREADY_PRESENT);
-//        }
-//    }
-//
-//    @Override
-//    public Boolean exists(String inputValue) {
-//        return userRepository.existsByEmailOrUsername(inputValue, inputValue);
-//    }
-//
-//    @Override
-//    public ResponseEntity<String> forgotPasswordRequest(ForgotPasswordDTO forgotPasswordDTO) {
-//        if (forgotPasswordDTO.getEmail() == null && forgotPasswordDTO.getUsername() == null)
-//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, Constants.USERNAME_OR_EMAIL_REQUIRED);
-//
-//        var token = UUID.randomUUID().toString();
-//        var user = userRepository.findByUsernameOrEmail(forgotPasswordDTO.getUsername(), forgotPasswordDTO.getEmail())
-//                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, Constants.USER_NOT_FOUND));
-//
-//        utils.sendMail(
-//                user.getEmail(),
-//                Constants.RESET_PASSWORD_SUBJECT,
-//                String.format(Constants.RESET_PASSWORD_CONTENT, userServiceProperties.getFrontEndUrl(), token));
-//        userRepository.save(user.setToken(token));
-//        return ResponseEntity.ok("password link sent.");
-//    }
-//
-//    @Override
-//    public ConfirmTokenDTO confirmToken(String resetToken, TokenType tokenType) {
-//        var user = userRepository.findByToken(resetToken);
-//        if (user.isEmpty())
-//            return new ConfirmTokenDTO().setAuthenticated(false);
-//        var userObject = user.get();
-//        var confirmToken = new ConfirmTokenDTO()
-//                .setAuthenticated(true)
-//                .setUsername(userObject.getUsername());
-//        if (tokenType.equals(TokenType.signup)) {
-//            if (!userObject.getIsActive())
-//                userRepository.save(userObject.setIsActive(true).setToken(null));
-//            return confirmToken.setTokenType(TokenType.signup);
-//        }
-//        return confirmToken.setTokenType(TokenType.forgot_password);
-//    }
-//
-//    @Override
-//    public ResponseEntity<String> resetPassword(UpdatePasswordDTO updatePasswordDTO) {
-//        var user = userRepository.findByUsernameAndToken(updatePasswordDTO.getUsername(), updatePasswordDTO.getToken())
-//                .orElseThrow(() -> new BadCredentialsException(Constants.USER_NOT_FOUND));
-//        userRepository.save(user.setPassword(passwordEncoder.encode(updatePasswordDTO.getNewPassword())).setToken(null));
-//        return ResponseEntity.ok("updated password successfully.");
-//    }
-//
-//    @Override
-//    public RefreshToken findByToken(String token) {
-//        return refreshTokenRepository.findByToken(token).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid Refresh Token."));
-//    }
-//
-//    @Override
-//    public RefreshToken createRefreshToken(String username) {
-//        RefreshToken refreshToken =
-//                new RefreshToken()
-//                .setToken(UUID.randomUUID().toString())
-//                .setUser(userRepository.findByUsername(username).orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "User not found")))
-//                .setExpiresIn(Instant.now().plusMillis(userServiceProperties.getRefreshTokenExpiryTimeInMs()));
-//
-//        return refreshTokenRepository.save(refreshToken);
-//    }
-//
-//    @Override
-//    public RefreshToken verifyExpiration(RefreshToken token) {
-//        if (token.getExpiresIn().compareTo(Instant.now()) < 0) {
-//            refreshTokenRepository.delete(token);
-//            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Refresh token was expired. Please make a new signin request");
-//        }
-//        return token;
-//    }
-//
-//    @Override
-//    public RefreshTokenResponseDto refreshToken(RefreshTokenRequestDTO refreshTokenRequestDTO) {
-//        String requestRefreshToken = refreshTokenRequestDTO.getRefreshToken();
-//
-//        RefreshToken refreshToken = this.verifyExpiration(this.findByToken(requestRefreshToken));
-//        User user = refreshToken.getUser();
-//        var authorities = new ArrayList<GrantedAuthority>();
-//        user
-//                .getRoles()
-//                .forEach(grantedAuthority -> authorities.add(new SimpleGrantedAuthority(grantedAuthority.getRoleType().toString())));
-//
-//
-//        String jwt = jwtUtils.generateJwt(refreshToken.getUser().getUsername(), jwtUtils.authorityToString(authorities));
-//
-//        return new RefreshTokenResponseDto()
-//                .setRefreshToken(refreshToken.getToken())
-//                .setToken(jwt)
-//                .setTokenType("Bearer");
-//    }
-//
-//    @Transactional
-//    public void deleteByUserId(Integer userId) {
-//        refreshTokenRepository.deleteByUser(userRepository.findById(userId).get());
-//    }
-//}
+package com.rafantasy.userservice.security.service;
+
+import com.rafantasy.userservice.feign.KeyCloakClient;
+import com.rafantasy.userservice.security.dto.LoginRequestDTO;
+import com.rafantasy.userservice.security.dto.LoginResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/**
+ * AuthService Implementation.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final KeyCloakClient keyCloakClient;
+
+    @Value("${keycloak.resource}")
+    private String clientId;
+
+    @Override
+    public LoginResponseDTO login(LoginRequestDTO loginRequestDTO) {
+
+        // Setting clientId and grantType
+        loginRequestDTO.setClient_id(clientId);
+        loginRequestDTO.setGrant_type("password");
+
+        return keyCloakClient.login(loginRequestDTO);
+    }
+}


### PR DESCRIPTION
closes #13 

- modified /api/auth/login endpoint to use keycloak's authentication endpoint. Achieved this using FeignClient
- Keycloak's endpoint used: http://localhost:8180/auth/realms/Rafantasy/protocol/openid-connect/token 
- Also added mapStruct dependency 