### PR TITLE
added feign + initial scheduler

### DIFF
--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -9,11 +9,12 @@
 	</parent>
 	<artifactId>scheduler</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>scheduler</name>
 	<packaging>jar</packaging>
+	<name>scheduler</name>
 	<description>Scheduler service </description>
 	<properties>
 		<java.version>11</java.version>
+		<spring-cloud.version>2020.0.0</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -33,6 +34,16 @@
 			<groupId>org.springframework.security</groupId>
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.rafantasy</groupId>
+			<artifactId>shared</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 

--- a/scheduler/src/main/java/com/rafantasy/scheduler/SchedulerApplication.java
+++ b/scheduler/src/main/java/com/rafantasy/scheduler/SchedulerApplication.java
@@ -2,10 +2,14 @@ package com.rafantasy.scheduler;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@ConfigurationPropertiesScan
+@EnableFeignClients(basePackages = {"com.rafantasy.shared.common.feign"})
 public class SchedulerApplication {
 
 	public static void main(String[] args) {

--- a/scheduler/src/main/java/com/rafantasy/scheduler/config/FeignConfig.java
+++ b/scheduler/src/main/java/com/rafantasy/scheduler/config/FeignConfig.java
@@ -1,0 +1,20 @@
+package com.rafantasy.scheduler.config;
+
+import feign.RequestInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignConfig {
+
+    @Autowired
+    TournamentApi tournamentApi;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            requestTemplate.header("x-rapidapi-key", tournamentApi.getXRapidapiKey());
+        };
+    }
+}

--- a/scheduler/src/main/java/com/rafantasy/scheduler/config/TournamentApi.java
+++ b/scheduler/src/main/java/com/rafantasy/scheduler/config/TournamentApi.java
@@ -1,0 +1,16 @@
+package com.rafantasy.scheduler.config;
+
+import lombok.Data;
+import lombok.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Value
+@ConstructorBinding
+@ConfigurationProperties(prefix = "livescore-api")
+public class TournamentApi {
+
+    String baseUrl;
+    String category;
+    String xRapidapiKey;
+}

--- a/scheduler/src/main/java/com/rafantasy/scheduler/scheduler/TournamentScheduler.java
+++ b/scheduler/src/main/java/com/rafantasy/scheduler/scheduler/TournamentScheduler.java
@@ -1,0 +1,25 @@
+package com.rafantasy.scheduler.scheduler;
+
+import com.rafantasy.scheduler.config.TournamentApi;
+import com.rafantasy.shared.common.feign.TennisClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TournamentScheduler {
+
+    private final TennisClient tennisClient;
+
+    private final TournamentApi tournamentApi;
+
+    @Scheduled(cron = "0 10 17 * * *", zone = "IST")
+    public void tournamentScheduler() {
+
+        // todo: map to proper dto
+        System.out.println(tennisClient.getTournamentMatches(tournamentApi.getCategory(),"wimbledon", "mens-singles"));
+
+    }
+}

--- a/scheduler/src/main/resources/application.yml
+++ b/scheduler/src/main/resources/application.yml
@@ -1,6 +1,21 @@
-server:
-  port: 8002
-
 spring:
   application:
     name: scheduler
+  datasource:
+    url: jdbc:postgresql://localhost:5430/rafantasy?applicationName=scheduler-service
+    username: postgres
+    password: password
+    driver-class-name: org.postgresql.Driver
+    platform: postgres
+    initialization-mode: never
+    tomcat:
+      max-wait: 60000
+
+server:
+  port: 8002
+
+livescore-api:
+  base-url: https://livescore6.p.rapidapi.com/matches/v2
+  x-rapidapi-key: 6809488b40msh5870951f23f1b4dp117513jsn564f929e06f2
+  category: tennis
+

--- a/shared/pom.xml
+++ b/shared/pom.xml
@@ -16,4 +16,11 @@
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
+    <dependencies>
+    <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-openfeign</artifactId>
+    </dependency>
+    </dependencies>
+
 </project>

--- a/shared/src/main/java/com/rafantasy/shared/common/feign/TennisClient.java
+++ b/shared/src/main/java/com/rafantasy/shared/common/feign/TennisClient.java
@@ -1,0 +1,15 @@
+package com.rafantasy.shared.common.feign;
+
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "tennis", url = "${livescore-api.base-url}")
+public interface TennisClient {
+
+    @GetMapping("/list-by-league")
+    String getTournamentMatches(@RequestParam(value = "Category") String category,
+                                @RequestParam(value = "Ccd", required = false) String ccd,
+                                @RequestParam(value = "Scd", required = false) String scd);
+}


### PR DESCRIPTION
closes #25 and #26 

* url used is "https://livescore6.p.rapidapi.com/matches/v2/list-by-league?Category=tennis&Ccd=wimbledon&Scd=mens-singles"
* ccd - tournament, scd - type (lets focus on mens singles for now)
